### PR TITLE
feat: simplify project

### DIFF
--- a/bucket_options.go
+++ b/bucket_options.go
@@ -50,7 +50,7 @@ func BucketOptions(opts ...BucketOption) BucketOption {
 	}
 }
 
-func (b *bucketBuilder) Build(ctx context.Context, name string) (*Bucket, error) {
+func (b *bucketBuilder) Build(ctx context.Context, name string) (Bucket, error) {
 	cli := b.cli
 	if cli == nil {
 		cfg, err := config.LoadDefaultConfig(ctx, b.cliOpts...)
@@ -89,7 +89,7 @@ func (b *bucketBuilder) Build(ctx context.Context, name string) (*Bucket, error)
 		}
 	}
 
-	return &Bucket{
+	return &bucket{
 		name:           name,
 		cli:            cli,
 		readChunkSize:  b.readChunkSize,
@@ -147,12 +147,11 @@ func WithBucketHost(url, region string, usePathStyle bool) BucketOption {
 	return func(b *bucketBuilder) {
 		b.cliOpts = append(b.cliOpts,
 			config.WithRegion(region),
-			config.WithEndpointResolverWithOptions(aws.EndpointResolverWithOptionsFunc(func(service, region string, opt ...interface{}) (aws.Endpoint, error) {
-				return aws.Endpoint{URL: url, SigningRegion: region}, nil
-			})),
 		)
 
 		b.s3Opts = append(b.s3Opts, func(o *s3.Options) {
+			o.BaseEndpoint = aws.String(url)
+			o.Region = region
 			o.UsePathStyle = true
 		})
 	}

--- a/doc.go
+++ b/doc.go
@@ -3,18 +3,18 @@
 // The s3io package provides a bucket that can interact with all elements within the bucket.
 // And can be configured with the "WithBucket..." options
 //
-//	bucket, err := s3io.OpenBucket(ctx, "my-bucket-name", s3io.WithBucketCredentials("access-key", "secret-key"))
+//	bucket, err := s3io.Open(ctx, "my-bucket-name", s3io.WithBucketCredentials("access-key", "secret-key"))
 //
-// There is an ObjectReader to preform read opperations on an s3 object.
+// There is an Reader to preform read opperations on an s3 object.
 //
-//	rd := bucket.NewReader(ctx, "path/to/object.txt", s3io.WithReaderConcurrency(10))
+//	rd := bucket.Get(ctx, "path/to/object.txt", s3io.WithReaderConcurrency(10))
 //
 //	_, err := io.Copy(os.Stdout, rd)
 //
-// And there is an ObjectWriter to preform write opperations on an s3 object.
+// And there is an Writer to preform write opperations on an s3 object.
 // Note The writer MUST close to safe the object.
 //
-//	wr := bucket.NewWriter(ctx, "path/to/object.txt")
+//	wr := bucket.Put(ctx, "path/to/object.txt")
 //	defer wr.Close()
 //
 //	_, err := io.WriteString(wr, "Hello world!")

--- a/example_test.go
+++ b/example_test.go
@@ -3,16 +3,14 @@ package s3io
 import (
 	"context"
 	"io"
-	"io/fs"
 	"log"
 	"os"
-	"text/template"
 )
 
-func ExampleObjectReader_Read() {
+func ExampleReader_Read() {
 	ctx := context.Background()
 
-	bucket, err := OpenBucket(ctx, "bucket-name",
+	bucket, err := Open(ctx, "bucket-name",
 		WithBucketCredentials("access-key", "access-secret"),
 		WithBucketCreateIfNotExists(),
 	)
@@ -20,7 +18,7 @@ func ExampleObjectReader_Read() {
 		log.Fatal(err)
 	}
 
-	rd := bucket.NewReader(ctx, "path/to/object.txt")
+	rd := bucket.Get(ctx, "path/to/object.txt")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -30,10 +28,10 @@ func ExampleObjectReader_Read() {
 	}
 }
 
-func ExampleObjectWriter_Write() {
+func ExampleWriter_Write() {
 	ctx := context.Background()
 
-	bucket, err := OpenBucket(ctx, "bucket-name",
+	bucket, err := Open(ctx, "bucket-name",
 		WithBucketCredentials("access-key", "access-secret"),
 		WithBucketCreateIfNotExists(),
 	)
@@ -41,7 +39,7 @@ func ExampleObjectWriter_Write() {
 		log.Fatal(err)
 	}
 
-	wr := bucket.NewWriter(ctx, "path/to/object.txt")
+	wr := bucket.Put(ctx, "path/to/object.txt")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -52,49 +50,6 @@ func ExampleObjectWriter_Write() {
 
 	// Note: you must close to finilize the upload
 	if err := wr.Close(); err != nil {
-		log.Fatal(err)
-	}
-}
-
-func ExampleBucket_Open() {
-	// you're able to use the bucket as fs.FS.
-	// here's an example how to use it with your html/template's.
-
-	ctx := context.Background()
-
-	bucket, err := OpenBucket(ctx, "bucket-name",
-		WithBucketCredentials("access-key", "access-secret"),
-		WithBucketCreateIfNotExists(),
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	templateEngine, err := template.ParseFS(bucket, "path/to/templates/*.html.tmpl")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	err = templateEngine.ExecuteTemplate(os.Stdout, "index.html.tmpl", map[string]any{
-		"arg1": "foo",
-		"arg2": "bar",
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// Or use it as simple subFS
-	subSys, err := fs.Sub(bucket, "path/to/subdir")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	file, err := subSys.Open("somefile")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	if _, err := io.Copy(os.Stdout, file); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jobstoit/s3io/v2
+module github.com/jobstoit/s3io/v3
 
 go 1.24
 

--- a/reader_test.go
+++ b/reader_test.go
@@ -14,50 +14,25 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/jobstoit/s3io/v2"
+	"github.com/jobstoit/s3io/v3"
 )
 
 func TestImplementFSFile(t *testing.T) {
 	t.Parallel()
 
-	var _ fs.File = &s3io.ObjectReader{}
+	var _ fs.File = &s3io.Reader{}
 }
 
 func TestImplementIOReader(t *testing.T) {
 	t.Parallel()
 
-	var _ io.Reader = &s3io.ObjectReader{}
+	var _ io.Reader = &s3io.Reader{}
 }
 
-func TestReadAll(t *testing.T) {
-	c, invocations, ranges := newDownloadRangeClient(buf12MB)
-
-	n, err := s3io.ReadAll(t.Context(), c, &s3.GetObjectInput{
-		Bucket: aws.String("bucket"),
-		Key:    aws.String("key"),
-	}, s3io.WithReaderConcurrency(1))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if e, a := len(buf12MB), len(n); e != a {
-		t.Errorf("expected %d buffer length, got %d", e, a)
-	}
-
-	if e, a := 4, *invocations; e != a {
-		t.Errorf("expect %v API calls, got %v", e, a)
-	}
-
-	expectRngs := []string{"bytes=0-0", "bytes=0-5242880", "bytes=5242881-10485761", "bytes=10485762-12582912"}
-	if e, a := expectRngs, *ranges; !reflect.DeepEqual(e, a) {
-		t.Errorf("expect %v ranges, got %v", e, a)
-	}
-}
-
-func TestObjectReaderSinglePart(t *testing.T) {
+func TestReaderSinglePart(t *testing.T) {
 	c, invocations, ranges := newDownloadRangeClient(buf2MB)
 
-	rd := s3io.NewObjectReader(t.Context(), c, &s3.GetObjectInput{
+	rd := s3io.NewReader(t.Context(), c, &s3.GetObjectInput{
 		Bucket: aws.String("bucket"),
 		Key:    aws.String("key"),
 	}, s3io.WithReaderConcurrency(1))
@@ -81,10 +56,10 @@ func TestObjectReaderSinglePart(t *testing.T) {
 	}
 }
 
-func TestObjectReaderMultiPart(t *testing.T) {
+func TestReaderMultiPart(t *testing.T) {
 	c, invocations, ranges := newDownloadRangeClient(buf12MB)
 
-	rd := s3io.NewObjectReader(t.Context(), c, &s3.GetObjectInput{
+	rd := s3io.NewReader(t.Context(), c, &s3.GetObjectInput{
 		Bucket: aws.String("bucket"),
 		Key:    aws.String("key"),
 	})


### PR DESCRIPTION
BREAKING CHANGE: update and simplify API.
Many of the added helper functions have bloated the project leaving
unneeded complexity in which function to use. This update should
encourage the use of the standard libary while using this libary only
for the core of interacting with objects through the reader and writer
it provides along with some simple bucket operations such as List, Exist
and Delete.
